### PR TITLE
Upgrade psycopg2 to psycopg "3"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -322,12 +322,12 @@ pool = ["psycopg-pool"]
 test = ["mypy (>=0.981)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-asyncio (>=0.17)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.10)"]
 
 [[package]]
-name = "psycopg2-binary"
-version = "2.9.4"
-description = "psycopg2 - Python-PostgreSQL Database Adapter"
+name = "psycopg-binary"
+version = "3.1.3"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "py"
@@ -503,7 +503,7 @@ watchdog = ["watchdog"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "7dea4f3d3cf7ec2448f44d8a87c39564fa330ec5adf4c408e2741de40d270dd0"
+content-hash = "21b54e5fdf2ed03cab9722e0abc998bcee806d3ad10ec47affdf2fafebcd4822"
 
 [metadata.files]
 attrs = [
@@ -723,66 +723,50 @@ psycopg = [
     {file = "psycopg-3.1.3-py3-none-any.whl", hash = "sha256:5d19e5d10c44fd858cfb72761635200f836847df0a07cb97c3aa5df264b1379d"},
     {file = "psycopg-3.1.3.tar.gz", hash = "sha256:d2c7c012e62083f800f9eb5eef849d5ed89940c3b31081d420279598f34c647e"},
 ]
-psycopg2-binary = [
-    {file = "psycopg2-binary-2.9.4.tar.gz", hash = "sha256:a6a2d3d75d8698dee492f4af7ad07606d0734e581edf9e2ce2f74b6fce90f42e"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-macosx_10_15_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:e72491d72870c3cb2f0d6f4174485533caec0e9ed7e717e2859b7cc7ff2ae1c4"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2903bf90b1e6bfc9bbfc94a1db0b50ffa9830a0ca4c042fbc38d93890c02ce08"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15e0ac0ed8a85f6049e836e95ddee627766561c85be8d23f4b3edb6ddbaa7310"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edf0a66ce9517365c7dcfed597894d8dd1f27b59e550b77a089054101435213b"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:61c6a258469c66412ae8358a0501df6ccb3bb48aa9c43b56624571ff9767f91d"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-manylinux_2_24_ppc64le.whl", hash = "sha256:704f1fcdc5b606b70563ea696c69bda90caee3a2f45ffc9cee60a901b394a79f"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:30200b07779446760813eef06098ec6d084131e4365b4e023eb43100de758b11"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f5fbb3b325c65010e04af206a9243e2df8606736c510c7f268aca6a93e5294a9"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:52383e932e6de5595963f9178cf2af7b9e1f3daacf5135b9c0e21aabbc5bf7c4"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0d8e0c9eec79fe1ae66691e06e3cc714da6fbd77981209bf32fa823c03dbaff8"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-win32.whl", hash = "sha256:161dc52a617f0bb610a87d391cb2e77fe65b89ebfbd752f4f3217dde701ea196"},
-    {file = "psycopg2_binary-2.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:33ac8b4754e6b6b21f3ee180da169d8526d91aee9408ec1fc573c16ab32b0207"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:7751b11cd7f6b952b4b5ec5b93b5be9ce20faba786c18c25c354f5d8717a173c"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b216a15e13f6e763db40ac3beb74b588650bc030d10a78fde182b88d273b82b5"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0eae72190be519bf2629062eab7ac8d4ceec5bd132953cefa1596584d86964fe"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-manylinux_2_24_aarch64.whl", hash = "sha256:fb639a0e65dce4a9cccbcbdd8ddd0c8c6ab10bca317b827a5c52ac3c3a4ad60a"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-manylinux_2_24_ppc64le.whl", hash = "sha256:80ed219ce6cb21a5b53ead0edf5b56b6d23de4cb95389ac606f47670474f4816"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:f78cafa25731e0b5aa16fe20bea1abf643d4e853f6bfb8a64421b06b878e2b88"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:34fd249275faa782c3a2016e86ac2330636ac58d731a1580e7d686e3976b9536"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:24d627ed69e754c48dd142a914124858c600b4108c92546eb0ba822e63c0c6e2"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:65d5f4e70a2d3fbaa1349236968792611088f3f2dccead36c1626e1d183cc327"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-win32.whl", hash = "sha256:ae5b41dbf7731b838021923edfbe3b5ccdec84d92d5795f5229c0d08d32509d9"},
-    {file = "psycopg2_binary-2.9.4-cp36-cp36m-win_amd64.whl", hash = "sha256:97e4f3d9b17d12e7c00cb1c29c0040044135cd5146838da4274615dbe0baae78"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-macosx_10_15_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:8660112e9127a019969a23c878e1b4a419e8a6427f9a9050c19830f152628c8a"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea8d5cd689fa7225d81ae0a049ba03e0165f4ed9ca083b19a405be9ad0b36845"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63edc507f8cbfbb5903adb75bad8a99f9798981c854df9119dbebab2ec3ee0e1"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:25e0517ad7ee3c5c3c69dbe3c1d95504c811e42f452b39a3505d0763b1f6caa0"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-manylinux_2_24_ppc64le.whl", hash = "sha256:0a9465f0aa36480c8e7614991cbe8ca8aa16b0517c5398a49648ce345e446c19"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:aff258af03dda9a990960a53759d10c3a9b936837c71fe2f3b581acd356b9121"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:576b9dfbcd154a0e8b5d9dae6316d037450e64a3b31df87dec71d88e2a2d5e5f"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:044b6ab68613de7ea1e63856627deea091bfea09dea5ab4f050b13250fd18cab"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7b47643c45e7619788c081d42e1d9d98c7c8a4933010a9967d097cc3c4c29f41"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-win32.whl", hash = "sha256:82df4a8600999c4c0cb7d6614df1bbdb3c74732f63e79f78487893ffbed3d083"},
-    {file = "psycopg2_binary-2.9.4-cp37-cp37m-win_amd64.whl", hash = "sha256:8d7bc25729bb6d96b44f49ad78fde0e27a1a867cb205322b7e5f5b49e04d6f1f"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-macosx_10_15_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:2f1ded23d17af0d738e7e78087f0b88a53228887845b1989b03af4dfd3fef703"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f225784812b2b57d340f2eb0d2cebef989dcc82c288f5553e28ee9767c7c8344"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89a86c2b35460700d04b4d6461153ab39ee85af5a5385acac9563a8310e6320a"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59a3010d566a48b919490a982f6807f68842686941dc12d568e129d9cd7703d6"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:02cde837df012fa5d579b9cf4bc8e1feb460f38d61f7a4ab4a919d55a9f6eeef"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-manylinux_2_24_ppc64le.whl", hash = "sha256:226f11be577b70a57f4910c0ee28591d4d9fcb3d455e966267179156ae2e0c41"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:181ac372a5a5308b4076933601a9b5f0cd139b389b0aa5e164786a2abbcdb978"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d5f27b1d1b56470385faa2b2636fcb823e7ac5b5b734e0aa76b14637c66eb3b7"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:55137faec669c4277c5687c6ce7c1fbc4dece0e2f14256ee808f4a652f0a2170"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ffb2f288f577a748cc23c65a818290755a4c2da1f87a40d7055b61a096d31e20"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-win32.whl", hash = "sha256:451550e0bb5889bbabbf92575a6d6eafced941cc28c86be6ae4667f81bf32d67"},
-    {file = "psycopg2_binary-2.9.4-cp38-cp38-win_amd64.whl", hash = "sha256:b23b25b1243576b952689966205ef7d4285688068b966a1ca0e620bcb390d483"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-macosx_10_15_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:7ad9d032dc1a31a86ca7b059f43554a049a2bfda8fe32d1492ad25f6686aff03"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7b01d07006a0ac2216921b69a220b9f0974345d0b1b36efaeabdc7550b1cc4f8"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb5341fc7c53fdd95ac2415be77b1de854ab266488cff71174ebb007baf0e675"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a431deb6ffdfa551f7400b3a94fa4b964837e67f49e3c37aa26d90dc75970816"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:d6ba33f39436191ece7ea2b3d0b4dff00af71acd5c6e6f1d6b7563aa7286e9f2"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-manylinux_2_24_ppc64le.whl", hash = "sha256:d6c5e1df6f427d7a82606cf8f07cf3ba9fb3f366804b01e65f1f00f8df6b54f1"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1c22c59ab7d9dc110d409445f111f58556bf699b0548f3fc5176684a29c629c4"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:b896637091cde69d170a89253dde9aee814b25ca204b7e213fd0a6462e666638"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:2535f44b00f26f6af0e949c825e6aecb9adcb56c965c17af5b97137fb69f00c0"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6a1618260a112a9c93504511f0b6254b4402a8c41b7130dc6d4c9e39aff3aa0c"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-win32.whl", hash = "sha256:e02f77b620ad6b36564fe41980865436912e21a3b1138cdde175cf24afde1bc5"},
-    {file = "psycopg2_binary-2.9.4-cp39-cp39-win_amd64.whl", hash = "sha256:44f5dc9b4384bafca8429759ce76c8960ffc2b583fcad9e5dfb3e5f4894269e4"},
+psycopg-binary = [
+    {file = "psycopg_binary-3.1.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:77a881b5bf6f7e5a5d9f0c0ad516e3577c1eff466398e50fc795cc703e022e7c"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:de1be1748d33ce3dbeacfec4e59886052dbbdff987ab9bd3025613d12fd716a3"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cf56d57d6f1abc90ce724a8f98555c72d8b0c970cbf8b5cd4bedb0d0b352ec"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5f3a0045946b1638a1d3a3c02313902d8cbd70c7dd973d9408fb9c341385c9a9"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5dba8866d9628916a249fc428bd7baef607e24a4b54d54825ec8866624114fb2"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18446766f3e1f3a8b6e2046a176c55992d2617b4c2b64c007969192210ee790f"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a8bd8becebc5e0945574cf99075a39f2942b885917c50091cea6ae2f7446e173"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c568aeaa0ec5f3130c49b713830bfe1ae85d89fb9300d14409b8dc4cfa86391d"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:fb7e9e17a8ec29d0199ee3f6f63fc10f7673887f0e13784764281a10bc6630da"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a799eaa75dedf60630665e2fe8f74bafa1a3a79b9a5f56769236eee131112a01"},
+    {file = "psycopg_binary-3.1.3-cp310-cp310-win_amd64.whl", hash = "sha256:ec872e3664334805e50c704ee9ba8fb6b7c5c0da269cd1e982792dd07b8d1ba8"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:94edc0bcaf336def6189e7613e3bfb1c182523c2d90300c0af6d846e38c9bdfa"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a70d12928b379603605e71fe0a319cec829d244ea9dad82cb9387946b81be095"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:211035cbd159842db7358069d135b2e4646036c33595aa4f0012644b2c64db24"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2be3770e558bed382b6bb5df39933501a92c7d2817e6965d270352a4af1cc281"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:355eb31f6ff5d4438cf7ac108c9ee1dec36950dd6b98651e5877be0dc699b49f"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:61eea4dd3da1947e7fee1cbf98924935c78247cb5426d6156693caec31506e53"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4a34d2487d2a62b66cc5b18f849749ee206294aa8a134c4adb8fafc0415a47f6"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:0d9fa168faf2b87d09148450819a7842d1ba499585e921725a1e0abfd132b770"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:69f5b4b1da0cb1432de36c044a705aff61a8ab130ccafab3548a7a3b789538fd"},
+    {file = "psycopg_binary-3.1.3-cp37-cp37m-win_amd64.whl", hash = "sha256:bac38acebd15d60b2a051491273c61905c17b1aa015b81d323e07449f39f6855"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:590fde0fbf5d94736c29bce210d9c975829f0eb667930102e7783c5ef35fa7c3"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6f5d16496db28a79bce834a5f919133ee491c4e5ae6ab555eef03d7590c77e05"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4460ebf333e6e7c212dfcd0d46bf9fd1dd04b406aaff34713d960f9e87f77d9"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:329a5515cdda94d13da64f3c5088307f91220538e4d6d089845e3f323d5c364d"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb1894056f00fba3d684b7bfc336fc25c18983861cadcfb0cad0be7eb841f485"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8bc439231b835d55127c955a7f8e95d3b88b9a4f7f6a43f1ec2117a959114c7"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4658c6945060363c7e96b7742f9b8082703b05310975070b3247f5c751f6307b"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e72011077546d7284b3bce59942a84805613eb1166fe7b6d6e6483b0a87ac2fc"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3df3283361e5e1a8e36ca8f788d83441551d3fdf50f53495156f535eb41c2dcc"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9f1e11796963adcd29000649310e68b95260a786b54438bec19c14deb5e568dc"},
+    {file = "psycopg_binary-3.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:7b1e2461562f9164a90b755702fbbd1b9141dce0b96a099371d7af0a7b7fdbe0"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7d8cca88f1b3e79895d9becbb9ed30b31324050e5502bd20bc94219cb80bc039"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e52062352bc133733d8dd284b1613a5d095fcae7ed0c608b89a6e4c674590bf9"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62baa7ed5e0507d4436d16fb5ff13a540850f30b29b06bccac5185e14270d651"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a07815dec9b06a686e61320a4f3733c4750cd44f5338d742d2fa86b72ff4ee4"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ae68869d7338f917db476da44928b58fd19137867694ff8075f44d2adab7f31"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ab64f067aa6db2119902d80d17d7cb3f0345bc55d56b1140985e478d0355f0f"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0a4b8a0935153dbfe4d9546b3b6594a0e5114d6ef17eb5ae57c83e581bd06c37"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f7bf6bd26271ce9fc3c9ce60570a67b12af4c00d4ddfe02442725816f639eeff"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:ccc2da1d4f5c9cea1686b645403e595d335b086792b240f83de331a4b4f8cfdc"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:680ec51370ba42adb69c7ebe29bf12bed6e56caa7d94e85f814423c1b24fc848"},
+    {file = "psycopg_binary-3.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:be1e65caeeff2a7b5454dfcea2af99d60e1a3ffade5a0dc627ef2b873a7419ac"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ flasgger = "^0.9.5"
 
 
 [tool.poetry.group.dev.dependencies]
-psycopg2-binary = "^2.9.3"
+psycopg-binary = "^3.1.3"
 pytest = "^7.1.3"
 black = "^22.10.0"
 isort = "^5.10.1"


### PR DESCRIPTION
Update dependencies with new versions of psycopg:
- dev: [psycopg2](https://pypi.org/project/psycopg2/)-binary==2.9.3 >>> [psycopg](https://pypi.org/project/psycopg/)-binary==3.1.3 (pypi links)
- prod: [psycopg2](https://www.psycopg.org/docs/install.html) >>> [psycopg](https://www.psycopg.org/psycopg3/docs/basic/install.html) "3" (install guide links)

Be aware not to use binary versions in production environment, for more info [read this docs](https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary)